### PR TITLE
Here is an example of codes to implement my suggestions.

### DIFF
--- a/generators/E906LegacyGen/SQPrimaryParticleGen.C
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.C
@@ -181,7 +181,6 @@ int SQPrimaryParticleGen::InitRun(PHCompositeNode* topNode)
 int SQPrimaryParticleGen::process_event(PHCompositeNode* topNode)
 {
 
-  _vertexGen->InitRun(topNode);
   TGeoManager* geoManager = PHGeomUtility::GetTGeoManager(topNode);
   double x_vtx,y_vtx,z_vtx;
   x_vtx=0.;
@@ -536,4 +535,24 @@ bool SQPrimaryParticleGen::generateDimuon(double mass, double xF, SQMCDimuon& di
     if(dimuon.fCosTh < cosThetaMin || dimuon.fCosTh >cosThetaMax) return false;
 
     return true;
+}
+
+void SQPrimaryParticleGen::setVertexXCenter(const double val)
+{
+  _vertexGen->setXCenter(val);
+}
+
+void SQPrimaryParticleGen::setVertexXWidth (const double val)
+{
+  _vertexGen->setXWidth(val);
+}
+
+void SQPrimaryParticleGen::setVertexYCenter(const double val)
+{
+  _vertexGen->setYCenter(val);
+}
+
+void SQPrimaryParticleGen::setVertexYWidth (const double val)
+{
+  _vertexGen->setYWidth(val);
 }

--- a/generators/E906LegacyGen/SQPrimaryParticleGen.h
+++ b/generators/E906LegacyGen/SQPrimaryParticleGen.h
@@ -83,6 +83,11 @@ public:
       massMin = mmin;
       massMax = mmax;
     }
+
+    void setVertexXCenter(const double val);
+    void setVertexXWidth (const double val);
+    void setVertexYCenter(const double val);
+    void setVertexYWidth (const double val);
     //@
 
  private:

--- a/generators/E906LegacyGen/SQPrimaryVertexGen.C
+++ b/generators/E906LegacyGen/SQPrimaryVertexGen.C
@@ -16,31 +16,16 @@ from Kun to E1039 experiment in Fun4All framework
 
 #include "SQPrimaryVertexGen.h"
 
- TF2* beam_global;
-
-SQPrimaryVertexGen::SQPrimaryVertexGen():
- _beam_profile(nullptr)
+SQPrimaryVertexGen::SQPrimaryVertexGen()
 {
-inited = false; 
+  beamProfile = new TF2("beamProfile", "exp(-0.5*pow((x-[0])/[1], 2)*exp(-0.5*pow((y-[2])/[3], 2))", -10., 10., -10., 10.);
+  beamProfile->SetParameters(0.0, 0.68, 0.0, 0.76);
 }
 
 SQPrimaryVertexGen::~SQPrimaryVertexGen()
 {
-  if (_beam_profile) delete _beam_profile;
-	
-  return;
+  if (beamProfile) delete beamProfile;
 }
-
-
-int SQPrimaryVertexGen::InitRun(PHCompositeNode* topNode){ 
-
-  if(_beam_profile){
-     beam_global = get_beam_profile();  
-   }
-  return 0;
-
-}
-
 
 void SQPrimaryVertexGen::traverse(TGeoNode* node,  double&xvertex,double&yvertex,double&zvertex) 
 {
@@ -278,18 +263,7 @@ void SQPrimaryVertexGen::traverse(TGeoNode* node,  double&xvertex,double&yvertex
 
 void SQPrimaryVertexGen::generateVtxPerp(double& x, double& y)
 {
-  
-  beamProfile = ::beam_global;
-  if(beamProfile)
-  { 
   beamProfile->GetRandom2(x, y);
-  }
-  else
-  {
-    x=gRandom->Gaus(0.,0.414);
-    y=gRandom->Gaus(0.,0.343);
-  }
-
 }
 
 void SQPrimaryVertexGen::findInteractingPiece()

--- a/generators/E906LegacyGen/SQPrimaryVertexGen.h
+++ b/generators/E906LegacyGen/SQPrimaryVertexGen.h
@@ -16,21 +16,16 @@ from Kun to E1039 experiment in Fun4All framework
 #include <TF2.h>
 #include <TVector3.h>
 #include <TH1F.h>
-#include <fun4all/SubsysReco.h>
 #include "SQBeamlineObject.h"
 
 class PHCompositeNode;
 class SQBeamlineObject;
 
-class SQPrimaryVertexGen: public SubsysReco
+class SQPrimaryVertexGen
 {
 public:
     SQPrimaryVertexGen();
     virtual ~SQPrimaryVertexGen();
-
-
-    //Initialize at the begining of Run
-    int InitRun(PHCompositeNode* topNode);
 
     //Tree traversal
     void traverse(TGeoNode* node, double&xvertex,double&yvertex,double&zvertex);
@@ -56,14 +51,14 @@ public:
    //get the reference to the chosen objects
    //const BeamlineObject& getInteractable() { return interactables[index]; } 
 
-    TF2* get_beam_profile() const {
-      return _beam_profile;
-    }
-
-    void set_beam_profile(TF2* BeamProfile) {
-      _beam_profile = BeamProfile;
-    }
-  
+    double getXCenter() const    { return beamProfile->GetParameter(0); }
+    double getXWidth () const    { return beamProfile->GetParameter(1); }
+    double getYCenter() const    { return beamProfile->GetParameter(2); }
+    double getYWidth () const    { return beamProfile->GetParameter(3); }
+    void   setXCenter(const double val) { beamProfile->SetParameter(0, val); }
+    void   setXWidth (const double val) { beamProfile->SetParameter(1, val); }
+    void   setYCenter(const double val) { beamProfile->SetParameter(2, val); }
+    void   setYWidth (const double val) { beamProfile->SetParameter(3, val); }
 
 private:
     //Array of beamline objects
@@ -80,13 +75,6 @@ private:
 
     //Beam profile
     TF2* beamProfile;
-
-    //flag to test if the generator has been initialized
-    bool inited;
-
-
-    TF2* _beam_profile;
-  
 };
 
 #endif


### PR DESCRIPTION
I have compiled this version fine, but haven't executed it.

No global variable is used.

`SQPrimaryVertexGen` is hidden in `SQPrimaryParticleGen`, and `beamProfile` (TF2) is hidden in `SQPrimaryVertexGen`.  User can change the parameters in `Fun4Sim.C` as follows;
```
SQPrimaryParticleGen *e906legacy = new  SQPrimaryParticleGen();
e906legacy->setVertexXWidth(0.1);
```